### PR TITLE
Fix jacob

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Disaggregation Modelling
 Version: 0.1.3
 Authors@R: c(
-    person("Anita", "Nandi", email = "anita.k.nandi@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-5087-2494")),
-    person("Tim", "Lucas", email =  "timcdlucas@gmail.com", role = "aut", comment = c(ORCID = "0000-0003-4694-8107")),
+    person("Anita", "Nandi", email = "anita.k.nandi@gmail.com", role = "aut", comment = c(ORCID = "0000-0002-5087-2494")),
+    person("Tim", "Lucas", email =  "timcdlucas@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-4694-8107")),
     person("Rohan", "Arambepola", email = "rarambepola@gmail.com", role = "aut"),
     person("Andre", "Python", email = "python.andre@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-8094-7226"))
     )

--- a/src/disaggregation.cpp
+++ b/src/disaggregation.cpp
@@ -127,7 +127,7 @@ Type objective_function<Type>::operator()()
     Type lambda = -log(prior_iideffect_sd_prob) / prior_iideffect_sd_max;
     Type log_pcdensity_iid = log(lambda / 2) - (3/2)*iideffect_log_tau - lambda * pow(iideffect_tau, -1/2);
     // log(iideffect_sd) from the Jacobian
-    nll -= log_pcdensity_iid + log(iideffect_sd);
+    nll -= log_pcdensity_iid + iideffect_log_tau;
     
     // Likelihood of random effect for polygons
     for(int p = 0; p < iideffect.size(); p++) {


### PR DESCRIPTION
Fix bug in disaggregation.cpp

The Jacobian correction for change of variables for the iid effect was wrong. We were adjusting by log(sd) rather than by log(tau).
